### PR TITLE
[stocks]: Convert money and volume related fields to uint64

### DIFF
--- a/actions/BuyStocksFromExchange.proto
+++ b/actions/BuyStocksFromExchange.proto
@@ -5,7 +5,7 @@ import "models/Transaction.proto";
 
 message BuyStocksFromExchangeRequest {
     uint32 stock_id = 1;
-    uint32 stock_quantity = 2;
+    uint64 stock_quantity = 2;
 }
 message BuyStocksFromExchangeResponse {
     enum StatusCode {

--- a/actions/GetMortgageDetails.proto
+++ b/actions/GetMortgageDetails.proto
@@ -14,5 +14,5 @@ message GetMortgageDetailsResponse {
     string     status_message = 2;
 
     // This will be updated when interest-based mortgage is implemented.
-    map<uint32, uint32> mortgage_map = 3; // key: stockid, value: number of stocks in mortgage
+    map<uint32, uint64> mortgage_map = 3; // key: stockid, value: number of stocks in mortgage
 }

--- a/actions/GetPortfolio.proto
+++ b/actions/GetPortfolio.proto
@@ -17,5 +17,5 @@ message GetPortfolioResponse {
     string     status_message = 2;
     string      session_id = 3;
     models.User user = 4;
-    map<uint32, int32>          stocks_owned = 5;
+    map<uint32, int64>          stocks_owned = 5;
 }

--- a/actions/Login.proto
+++ b/actions/Login.proto
@@ -22,7 +22,7 @@ message LoginResponse {
     string      session_id = 3;
     models.User user = 4;
 
-    map<uint32, int32>          stocks_owned = 5;
+    map<uint32, int64>          stocks_owned = 5;
     map<uint32, models.Stock>   stock_list = 6;
     map<string, int32>          constants = 7;
 

--- a/actions/MortgageStocks.proto
+++ b/actions/MortgageStocks.proto
@@ -5,7 +5,7 @@ import "models/Transaction.proto";
 
 message MortgageStocksRequest {
     uint32 stock_id = 1;
-    uint32 stock_quantity = 2;
+    uint64 stock_quantity = 2;
 }
 
 message MortgageStocksResponse {

--- a/actions/PlaceOrder.proto
+++ b/actions/PlaceOrder.proto
@@ -7,7 +7,7 @@ message PlaceOrderRequest {
     bool   is_ask = 1;
     uint32 stock_id = 2;
     models.OrderType order_type = 3;
-    uint32 price = 4;
+    uint64 price = 4;
     uint32 stock_quantity = 5;
 }
 

--- a/actions/PlaceOrder.proto
+++ b/actions/PlaceOrder.proto
@@ -8,7 +8,7 @@ message PlaceOrderRequest {
     uint32 stock_id = 2;
     models.OrderType order_type = 3;
     uint64 price = 4;
-    uint32 stock_quantity = 5;
+    uint64 stock_quantity = 5;
 }
 
 message PlaceOrderResponse {

--- a/actions/RetrieveMortgageStocks.proto
+++ b/actions/RetrieveMortgageStocks.proto
@@ -5,7 +5,7 @@ import "models/Transaction.proto";
 
 message RetrieveMortgageStocksRequest {
     uint32 stock_id = 1;
-    uint32 stock_quantity = 2;
+    uint64 stock_quantity = 2;
 }
 
 message RetrieveMortgageStocksResponse {

--- a/datastreams/MarketDepth.proto
+++ b/datastreams/MarketDepth.proto
@@ -4,16 +4,16 @@ package dalalstreet.api.datastreams;
 
 message Trade {
     uint64 trade_price = 1;
-    uint32 trade_quantity = 2;
+    uint64 trade_quantity = 2;
     string trade_time = 3;
 }
 
 message MarketDepthUpdate {
     uint32 stock_id = 1;
-    map<uint64, uint32> ask_depth = 2;
-    map<uint64, uint32> bid_depth = 3;
-    map<uint64, int32> ask_depth_diff = 4;
-    map<uint64, int32> bid_depth_diff = 5;
+    map<uint64, uint64> ask_depth = 2;
+    map<uint64, uint64> bid_depth = 3;
+    map<uint64, int64> ask_depth_diff = 4;
+    map<uint64, int64> bid_depth_diff = 5;
     repeated Trade latest_trades = 6;
     repeated Trade latest_trades_diff = 7;
 }

--- a/datastreams/MarketDepth.proto
+++ b/datastreams/MarketDepth.proto
@@ -3,17 +3,17 @@ syntax = "proto3";
 package dalalstreet.api.datastreams;
 
 message Trade {
-    uint32 trade_price = 1;
+    uint64 trade_price = 1;
     uint32 trade_quantity = 2;
     string trade_time = 3;
 }
 
 message MarketDepthUpdate {
     uint32 stock_id = 1;
-    map<uint32, uint32> ask_depth = 2;
-    map<uint32, uint32> bid_depth = 3;
-    map<uint32, int32> ask_depth_diff = 4;
-    map<uint32, int32> bid_depth_diff = 5;
+    map<uint64, uint32> ask_depth = 2;
+    map<uint64, uint32> bid_depth = 3;
+    map<uint64, int32> ask_depth_diff = 4;
+    map<uint64, int32> bid_depth_diff = 5;
     repeated Trade latest_trades = 6;
     repeated Trade latest_trades_diff = 7;
 }

--- a/datastreams/MyOrders.proto
+++ b/datastreams/MyOrders.proto
@@ -11,7 +11,7 @@ message MyOrderUpdate {
     bool   is_closed = 4;
     bool   is_new_order = 5;
     uint32 stock_id = 6;
-    uint32 order_price = 7;
+    uint64 order_price = 7;
     models.OrderType order_type = 8;
     uint32 stock_quantity = 9;
 }

--- a/datastreams/MyOrders.proto
+++ b/datastreams/MyOrders.proto
@@ -7,11 +7,11 @@ import "models/OrderType.proto";
 message MyOrderUpdate {
     uint32 id = 1;
     bool   is_ask = 2;
-    uint32 trade_quantity = 3;
+    uint64 trade_quantity = 3;
     bool   is_closed = 4;
     bool   is_new_order = 5;
     uint32 stock_id = 6;
     uint64 order_price = 7;
     models.OrderType order_type = 8;
-    uint32 stock_quantity = 9;
+    uint64 stock_quantity = 9;
 }

--- a/datastreams/StockExchange.proto
+++ b/datastreams/StockExchange.proto
@@ -4,8 +4,8 @@ package dalalstreet.api.datastreams;
 
 message StockExchangeDataPoint {
     uint64 price = 1;
-    uint32 stocks_in_exchange = 2;
-    uint32 stocks_in_market = 3;
+    uint64 stocks_in_exchange = 2;
+    uint64 stocks_in_market = 3;
 }
 
 message StockExchangeUpdate {

--- a/datastreams/StockExchange.proto
+++ b/datastreams/StockExchange.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package dalalstreet.api.datastreams;
 
 message StockExchangeDataPoint {
-    uint32 price = 1;
+    uint64 price = 1;
     uint32 stocks_in_exchange = 2;
     uint32 stocks_in_market = 3;
 }

--- a/datastreams/StockPrices.proto
+++ b/datastreams/StockPrices.proto
@@ -3,5 +3,5 @@ syntax = "proto3";
 package dalalstreet.api.datastreams;
 
 message StockPricesUpdate {
-    map<uint32, uint32> prices = 1; // key: stockId, value: price
+    map<uint32, uint64> prices = 1; // key: stockId, value: price
 }

--- a/models/Ask.proto
+++ b/models/Ask.proto
@@ -10,8 +10,8 @@ message Ask {
   uint32 stock_id = 3;
   uint64 price = 4;
   OrderType order_type = 5;
-  uint32 stock_quantity = 6;
-  uint32 stock_quantity_fulfilled = 7;
+  uint64 stock_quantity = 6;
+  uint64 stock_quantity_fulfilled = 7;
   bool is_closed = 8;
   string created_at = 9;
   string updated_at = 10;

--- a/models/Ask.proto
+++ b/models/Ask.proto
@@ -8,7 +8,7 @@ message Ask {
   uint32 id = 1;
   uint32 user_id = 2;
   uint32 stock_id = 3;
-  uint32 price = 4;
+  uint64 price = 4;
   OrderType order_type = 5;
   uint32 stock_quantity = 6;
   uint32 stock_quantity_fulfilled = 7;

--- a/models/Bid.proto
+++ b/models/Bid.proto
@@ -8,7 +8,7 @@ message Bid {
   uint32 id = 1;
   uint32 user_id = 2;
   uint32 stock_id = 3;
-  uint32 price = 4;
+  uint64 price = 4;
   OrderType order_type = 5;
   uint32 stock_quantity = 6;
   uint32 stock_quantity_fulfilled = 7;

--- a/models/Bid.proto
+++ b/models/Bid.proto
@@ -10,8 +10,8 @@ message Bid {
   uint32 stock_id = 3;
   uint64 price = 4;
   OrderType order_type = 5;
-  uint32 stock_quantity = 6;
-  uint32 stock_quantity_fulfilled = 7;
+  uint64 stock_quantity = 6;
+  uint64 stock_quantity_fulfilled = 7;
   bool is_closed = 8;
   string created_at = 9;
   string updated_at = 10;

--- a/models/LeaderboardRow.proto
+++ b/models/LeaderboardRow.proto
@@ -7,8 +7,8 @@ message LeaderboardRow {
     uint32 user_id = 2;
     string user_name = 3;
     uint32 rank = 4;
-    uint32 cash = 5;
-    uint32 debt = 6;
-    int32  stock_worth = 7;
-    int32  total_worth = 8;
+    uint64 cash = 5;
+    uint64 debt = 6;
+    int64  stock_worth = 7;
+    int64  total_worth = 8;
 }

--- a/models/MortgageDetail.proto
+++ b/models/MortgageDetail.proto
@@ -6,5 +6,5 @@ message MortgageDetail {
     uint32 id = 1;
     uint32 user_id = 2;
     uint32 stock_id = 3;
-    uint32 stocks_in_bank = 4;
+    uint64 stocks_in_bank = 4;
 }

--- a/models/Stock.proto
+++ b/models/Stock.proto
@@ -7,16 +7,16 @@ message Stock {
   string short_name = 2;
   string full_name = 3;
   string description = 4;
-  uint32 current_price = 5;
-  uint32 day_high = 6;
-  uint32 day_low = 7;
-  uint32 all_time_high = 8;
-  uint32 all_time_low = 9;
+  uint64 current_price = 5;
+  uint64 day_high = 6;
+  uint64 day_low = 7;
+  uint64 all_time_high = 8;
+  uint64 all_time_low = 9;
   uint32 stocks_in_exchange = 10;
   uint32 stocks_in_market = 11;
   bool up_or_down = 12;
-  uint32 previous_day_close = 13;
-  uint32 avg_last_price = 14;
+  uint64 previous_day_close = 13;
+  uint64 avg_last_price = 14;
   string created_at = 15;
   string updated_at = 16;
 }

--- a/models/Stock.proto
+++ b/models/Stock.proto
@@ -12,8 +12,8 @@ message Stock {
   uint64 day_low = 7;
   uint64 all_time_high = 8;
   uint64 all_time_low = 9;
-  uint32 stocks_in_exchange = 10;
-  uint32 stocks_in_market = 11;
+  uint64 stocks_in_exchange = 10;
+  uint64 stocks_in_market = 11;
   bool up_or_down = 12;
   uint64 previous_day_close = 13;
   uint64 avg_last_price = 14;

--- a/models/StockHistory.proto
+++ b/models/StockHistory.proto
@@ -4,11 +4,11 @@ package dalalstreet.api.models;
 
 message StockHistory {
   uint32 stock_id = 1;
-  uint32 close = 2;
+  uint64 close = 2;
   string created_at = 3;
   uint32 interval = 4;
-  uint32 open = 5;
-  uint32 high = 6;
-  uint32 low = 7;
+  uint64 open = 5;
+  uint64 high = 6;
+  uint64 low = 7;
   uint32 volume = 8;
 }

--- a/models/StockHistory.proto
+++ b/models/StockHistory.proto
@@ -10,5 +10,5 @@ message StockHistory {
   uint64 open = 5;
   uint64 high = 6;
   uint64 low = 7;
-  uint32 volume = 8;
+  uint64 volume = 8;
 }

--- a/models/Transaction.proto
+++ b/models/Transaction.proto
@@ -14,8 +14,8 @@ message Transaction {
   uint32 user_id = 2;
   uint32 stock_id = 3;
   TransactionType type = 4;
-  int32 stock_quantity = 5;
+  int64 stock_quantity = 5;
   uint64 price = 6;
-  int32 total = 7;
+  int64 total = 7;
   string created_at = 8;
 }

--- a/models/Transaction.proto
+++ b/models/Transaction.proto
@@ -15,7 +15,7 @@ message Transaction {
   uint32 stock_id = 3;
   TransactionType type = 4;
   int32 stock_quantity = 5;
-  uint32 price = 6;
+  uint64 price = 6;
   int32 total = 7;
   string created_at = 8;
 }

--- a/models/User.proto
+++ b/models/User.proto
@@ -7,7 +7,7 @@ message User {
   string email = 2;
   string name = 3;
   uint64 cash = 4;
-  int32 total = 5;
+  int64 total = 5;
   string created_at = 6;
   bool is_human=7;
 }

--- a/models/User.proto
+++ b/models/User.proto
@@ -6,7 +6,7 @@ message User {
   uint32 id = 1;
   string email = 2;
   string name = 3;
-  uint32 cash = 4;
+  uint64 cash = 4;
   int32 total = 5;
   string created_at = 6;
   bool is_human=7;


### PR DESCRIPTION
Currently all money and volume related fields are uint32. This has been converted to uint64 just incase someone gets absurdly rich.