### PR TITLE
Add java multiple files option

### DIFF
--- a/actions/BuyStocksFromExchange.proto
+++ b/actions/BuyStocksFromExchange.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 import "models/Transaction.proto";
 
 message BuyStocksFromExchangeRequest {

--- a/actions/CancelOrder.proto
+++ b/actions/CancelOrder.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 message CancelOrderRequest {
     uint32 order_id = 1;
     bool   is_ask = 2;

--- a/actions/ChangePassword.proto
+++ b/actions/ChangePassword.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
 
 message ChangePasswordRequest{
     

--- a/actions/CreateBot.proto
+++ b/actions/CreateBot.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 import "models/User.proto";
 
 message CreateBotRequest {

--- a/actions/ForgotPassword.proto
+++ b/actions/ForgotPassword.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
 
 message ForgotPasswordRequest{
    string email=1;

--- a/actions/GetCompanyProfile.proto
+++ b/actions/GetCompanyProfile.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 import "models/Stock.proto";
 
 message GetCompanyProfileRequest {

--- a/actions/GetLeaderboard.proto
+++ b/actions/GetLeaderboard.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 import "models/LeaderboardRow.proto";
 
 message GetLeaderboardRequest {

--- a/actions/GetMarketEvents.proto
+++ b/actions/GetMarketEvents.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 import "models/MarketEvent.proto";
 
 message GetMarketEventsRequest {

--- a/actions/GetMortgageDetails.proto
+++ b/actions/GetMortgageDetails.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 import "models/MortgageDetail.proto";
 
 message GetMortgageDetailsRequest {

--- a/actions/GetMyOrders.proto
+++ b/actions/GetMyOrders.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 import "models/Ask.proto";
 import "models/Bid.proto";
 

--- a/actions/GetNotifications.proto
+++ b/actions/GetNotifications.proto
@@ -3,6 +3,8 @@ package dalalstreet.api.actions;
 
 import "models/Notification.proto";
 
+option java_multiple_files=true;
+
 message GetNotificationsRequest {
     uint32 last_notification_id = 1;
     uint32 count = 2;

--- a/actions/GetPortfolio.proto
+++ b/actions/GetPortfolio.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 import "models/User.proto";
 
 message GetPortfolioRequest {

--- a/actions/GetStockHistory.proto
+++ b/actions/GetStockHistory.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 import "models/StockHistory.proto";
 
 enum StockHistoryResolution {

--- a/actions/GetTransactions.proto
+++ b/actions/GetTransactions.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 import "models/Transaction.proto";
 
 message GetTransactionsRequest {

--- a/actions/Login.proto
+++ b/actions/Login.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 import "models/Stock.proto";
 import "models/User.proto";
 

--- a/actions/Logout.proto
+++ b/actions/Logout.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 message LogoutRequest {
     // No request data
 }

--- a/actions/MortgageStocks.proto
+++ b/actions/MortgageStocks.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 import "models/Transaction.proto";
 
 message MortgageStocksRequest {

--- a/actions/PlaceOrder.proto
+++ b/actions/PlaceOrder.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 import "models/OrderType.proto";
 
 message PlaceOrderRequest {

--- a/actions/Register.proto
+++ b/actions/Register.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 message RegisterRequest{
     string email = 1;
     string password = 2;

--- a/actions/RetrieveMortgageStocks.proto
+++ b/actions/RetrieveMortgageStocks.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 import "models/Transaction.proto";
 
 message RetrieveMortgageStocksRequest {

--- a/actions/SendDividends.proto
+++ b/actions/SendDividends.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 message SendDividendsRequest {
     uint32 stock_id = 1;
     uint64 dividend_amount = 2;

--- a/actions/SendNews.proto
+++ b/actions/SendNews.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package dalalstreet.api.actions;
 
+option java_multiple_files=true;
+
 message SendNewsRequest {
     string news = 1;
 }

--- a/datastreams/MarketDepth.proto
+++ b/datastreams/MarketDepth.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.datastreams;
 
+option java_multiple_files=true;
+
 message Trade {
     uint64 trade_price = 1;
     uint64 trade_quantity = 2;

--- a/datastreams/MarketEvents.proto
+++ b/datastreams/MarketEvents.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.datastreams;
 
+option java_multiple_files=true;
+
 import "models/MarketEvent.proto";
 
 message MarketEventUpdate {

--- a/datastreams/MyOrders.proto
+++ b/datastreams/MyOrders.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.datastreams;
 
+option java_multiple_files=true;
+
 import "models/OrderType.proto";
 
 message MyOrderUpdate {

--- a/datastreams/Notifications.proto
+++ b/datastreams/Notifications.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.datastreams;
 
+option java_multiple_files=true;
+
 import "models/Notification.proto";
 
 message NotificationUpdate {

--- a/datastreams/StockExchange.proto
+++ b/datastreams/StockExchange.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.datastreams;
 
+option java_multiple_files=true;
+
 message StockExchangeDataPoint {
     uint64 price = 1;
     uint64 stocks_in_exchange = 2;

--- a/datastreams/StockHistory.proto
+++ b/datastreams/StockHistory.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.datastreams;
 
+option java_multiple_files=true;
+
 import "models/StockHistory.proto";
 
 message StockHistoryUpdate {

--- a/datastreams/StockPrices.proto
+++ b/datastreams/StockPrices.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.datastreams;
 
+option java_multiple_files=true;
+
 message StockPricesUpdate {
     map<uint32, uint64> prices = 1; // key: stockId, value: price
 }

--- a/datastreams/Subscribe.proto
+++ b/datastreams/Subscribe.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package dalalstreet.api.datastreams;
 
+option java_multiple_files=true;
+
 enum DataStreamType {
     MARKET_DEPTH = 0;
     TRANSACTIONS = 1;

--- a/datastreams/Transactions.proto
+++ b/datastreams/Transactions.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.datastreams;
 
+option java_multiple_files=true;
+
 import "models/Transaction.proto";
 
 message TransactionUpdate {

--- a/models/Ask.proto
+++ b/models/Ask.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.models;
 
+option java_multiple_files=true;
+
 import "models/OrderType.proto";
 
 message Ask {

--- a/models/Bid.proto
+++ b/models/Bid.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.models;
 
+option java_multiple_files=true;
+
 import "models/OrderType.proto";
 
 message Bid {

--- a/models/LeaderboardRow.proto
+++ b/models/LeaderboardRow.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.models;
 
+option java_multiple_files=true;
+
 message LeaderboardRow {
     uint32 id = 1;
     uint32 user_id = 2;

--- a/models/MarketEvent.proto
+++ b/models/MarketEvent.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.models;
 
+option java_multiple_files=true;
+
 message MarketEvent {
     uint32 id = 1;
     uint32 stock_id = 2;

--- a/models/MortgageDetail.proto
+++ b/models/MortgageDetail.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.models;
 
+option java_multiple_files=true;
+
 message MortgageDetail {
     uint32 id = 1;
     uint32 user_id = 2;

--- a/models/Notification.proto
+++ b/models/Notification.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.models;
 
+option java_multiple_files=true;
+
 message Notification {
   uint32 id = 1;
   uint32 user_id = 2;

--- a/models/OrderFill.proto
+++ b/models/OrderFill.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.models;
 
+option java_multiple_files=true;
+
 message OrderFill {
   uint32 transaction_id = 1;
   uint32 bid_id = 2;

--- a/models/OrderType.proto
+++ b/models/OrderType.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.models;
 
+option java_multiple_files=true;
+
 enum OrderType {
     LIMIT = 0;
     MARKET = 1;

--- a/models/Stock.proto
+++ b/models/Stock.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.models;
 
+option java_multiple_files=true;
+
 message Stock {
   uint32 id = 1;
   string short_name = 2;

--- a/models/StockHistory.proto
+++ b/models/StockHistory.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.models;
 
+option java_multiple_files=true;
+
 message StockHistory {
   uint32 stock_id = 1;
   uint64 close = 2;

--- a/models/Transaction.proto
+++ b/models/Transaction.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.models;
 
+option java_multiple_files=true;
+
 enum TransactionType {
     FROM_EXCHANGE_TRANSACTION = 0;
     ORDER_FILL_TRANSACTION = 1;

--- a/models/User.proto
+++ b/models/User.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package dalalstreet.api.models;
 
+option java_multiple_files=true;
+
 message User {
   uint32 id = 1;
   string email = 2;


### PR DESCRIPTION
Set

option java_multiple_files = true;

Causes top-level messages, enums, and services to be defined at the package level, rather than inside an outer class named after the .proto file. Options do not change the overall meaning of a declaration, but affects the way it is handled in a particular context (here Android app).